### PR TITLE
fix: use JDK instead of JRE

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 Setup script for getting a development environment setup on RHEL 9.0 or Ubuntu 22.04 for Liberty InstantOn
 
 Run the provided `instanton-setup.sh` using the `-j` option to point to a build of
-the Semeru that includes CRIU Support.  For example, the latest Semeru Java 21 release: https://github.com/ibmruntimes/semeru21-binaries/releases/download/jdk-21.0.6%2B7_openj9-0.49.0/ibm-semeru-open-jre_x64_linux_21.0.6_7_openj9-0.49.0.tar.gz
+the Semeru that includes CRIU Support.  For example, the latest Semeru Java 21 release: https://github.com/ibmruntimes/semeru21-binaries/releases/download/jdk-21.0.6%2B7_openj9-0.49.0/ibm-semeru-open-jdk_x64_linux_21.0.6_7_openj9-0.49.0.tar.gz
 
 For example:
 
 ```
-./instanton-setup.sh -j https://github.com/ibmruntimes/semeru21-binaries/releases/download/jdk-21.0.6%2B7_openj9-0.49.0/ibm-semeru-open-jre_x64_linux_21.0.6_7_openj9-0.49.0.tar.gz
+./instanton-setup.sh -j https://github.com/ibmruntimes/semeru21-binaries/releases/download/jdk-21.0.6%2B7_openj9-0.49.0/ibm-semeru-open-jdk_x64_linux_21.0.6_7_openj9-0.49.0.tar.gz
 ```


### PR DESCRIPTION
Assembling Open Liberty requires the JDK otherwise you can expect the following error from gradle: 

```sh
> Toolchain installation '/opt/java/openjdk' does not provide the required capabilities: [JAVA_COMPILER]
```